### PR TITLE
Fix/change-chain-in-modal

### DIFF
--- a/app/bridge/components/gravityConfirmationModal.tsx
+++ b/app/bridge/components/gravityConfirmationModal.tsx
@@ -4,7 +4,6 @@ import Icon from "@/components/icon/icon";
 import Spacer from "@/components/layout/spacer";
 import Modal from "@/components/modal/modal";
 import Text from "@/components/text";
-import { TX_SIGN_ERRORS } from "@/config/consts/errors";
 import { GRAVITY_BRIGDE_EVM } from "@/config/networks";
 import useScreenSize from "@/hooks/helpers/useScreenSize";
 import { useState } from "react";
@@ -27,10 +26,9 @@ const GravityConfirmationModal = ({
 
   async function handleConfirm() {
     try {
-      await switchNetwork({ chainId: GRAVITY_BRIGDE_EVM.chainId });
       const network = getNetwork();
       if (!network.chain || network.chain.id !== GRAVITY_BRIGDE_EVM.chainId) {
-        throw new Error(TX_SIGN_ERRORS.SWITCH_CHAIN_ERROR());
+        await switchNetwork({ chainId: GRAVITY_BRIGDE_EVM.chainId });
       }
 
       setAddChainError(null);


### PR DESCRIPTION
When you click on the bridge out, it shows a popup that you have to click on "I'm using a supported wallet". That button throws an exception when your selected chain is already Gravity, you have to change the network first to something else then you can click on that button